### PR TITLE
column to .col & sass specific cleanup

### DIFF
--- a/less/grid.less
+++ b/less/grid.less
@@ -9,54 +9,65 @@
 	overflow: auto; /* required - without this, the page layout is screwed up */
 }
 
-column {
+.col {
 	float: left;
-	margin: auto 1%;
 }
-.ie column {
+
+.ie .col {
 	margin: auto .7%;
 }
+
 .c12 {
-	width: 98%;
+	width: 100%;
 }
+
 .c11 {
-	width: 89.66%;
+	width: 91.66%;
 }
+
 .c10 {
-	width: 81.33%;
+	width: 83.33%;
 }
+
 .c9 {
-	width: 73%;
+	width: 75%;
 }
+
 .c8 {
-	width: 64.66%;
+	width: 66.66%;
 }
+
 .c7 {
-	width: 56.33%;
+	width: 58.33%;
 }
+
 .c6 {
-	width: 48%;
+	width: 50%;
 }
+
 .c5 {
-	width: 39.66%
+	width: 41.66%
 }
+
 .c4 {
-	width: 31.33%;
+	width: 33.33%;
 }
+
 .c3 {
-	width: 23%;
+	width: 25%;
 }
+
 .c2 {
-	width: 14.66%;
+	width: 16.66%;
 }
+
 .c1 {
-	width: 6.33%;
+	width: 8.33%;
 }
 
 /* For smaller screens, change all columns to 100% width */
 @media (max-width:870px) {
-	.row column {
-		margin: 1% auto;
+	.row .col {
 		width: 100%;
 	}
 }

--- a/less/grid.less
+++ b/less/grid.less
@@ -13,10 +13,6 @@
 	float: left;
 }
 
-.ie .col {
-	margin: auto .7%;
-}
-
 .c12 {
 	width: 100%;
 }

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -1,4 +1,4 @@
-@if $import-grid == true{
+@if $import-grid == true {
 //-------------------------------------------------------------------
 //  Grid system responsive code is in _general.scss
 //  A hack (for old IEs) for the grid system is located in _iehacks.scss
@@ -14,56 +14,40 @@
   overflow: auto; // needed for proper formed layout
 }
 
-column {
+.col {
   float: left;
   margin: auto 1%;
 }
 
 // IE Grid Fix
-.ie column {
+.ie .col {
   margin: auto .7%;
 }
 
-.c12 {
-	width: 98%;
-}
-.c11 {
-	width: 89.66%;
-}
-.c10 {
-	width: 81.33%;
-}
-.c9 {
-	width: 73%;
-}
-.c8 {
-	width: 64.66%;
-}
-.c7 {
-	width: 56.33%;
-}
-.c6 {
-	width: 48%;
-}
-.c5 {
-	width: 39.66%
-}
-.c4 {
-	width: 31.33%;
-}
-.c3 {
-	width: 23%;
-}
-.c2 {
-	width: 14.66%;
-}
-.c1 {
-	width: 6.33%;
-}
 
+$grid-list: (
+  c1   6.33%,
+  c2   14.66%,
+  c3   23%,
+  c4   31.33%,
+  c5   39.66%,
+  c6   48%,
+  c7   56.33%,
+  c8   64.66%,
+  c9   73%,
+  c10  81.33%,
+  c11  89.66%,
+  c12  98%
+);
+
+@each $value in $grid-list {
+  .#{nth($value, 1)} {
+    width: nth($value, 2);
+  }
+}
 
 @media (max-width:870px) {
-  .row column {
+  .row .col {
     margin: 1% auto;
     width: 100%;
   }

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -16,28 +16,21 @@
 
 .col {
   float: left;
-  margin: auto 1%;
 }
-
-// IE Grid Fix
-.ie .col {
-  margin: auto .7%;
-}
-
 
 $grid-list: (
-  c1   6.33%,
-  c2   14.66%,
-  c3   23%,
-  c4   31.33%,
-  c5   39.66%,
-  c6   48%,
-  c7   56.33%,
-  c8   64.66%,
-  c9   73%,
-  c10  81.33%,
-  c11  89.66%,
-  c12  98%
+  c1   8.33%,
+  c2   16.66%,
+  c3   25%,
+  c4   33.33%,
+  c5   41.66%,
+  c6   50%,
+  c7   58.33%,
+  c8   66.66%,
+  c9   75%,
+  c10  83.33%,
+  c11  91.66%,
+  c12  100%
 );
 
 @each $value in $grid-list {
@@ -48,7 +41,6 @@ $grid-list: (
 
 @media (max-width:870px) {
   .row .col {
-    margin: 1% auto;
     width: 100%;
   }
 }

--- a/sass/_navbar.scss
+++ b/sass/_navbar.scss
@@ -59,10 +59,9 @@
     // transition: max-height .5s ease-in-out, height .5s ease-in-out;
 
     &:focus {
-      /* Necesary for animations
-      max-height: 500px;
-      height: 100%;
-      */
+      // -- Necesary for animations
+      // max-height: 500px;
+      // height: 100%;
       height: auto;
     }
 


### PR DESCRIPTION
So in the same vein as converting ico to .ico, we should probably do the same with "column".

I'm proposing changing it to .col.  But if you would rather keep it as .column, or .c to match the width classes, just let me know.

/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

convert .c# over to a sass list / @each directive to streamline output of classes.

convert "column" element over to .col class

convert css comments to sass comments in navbar file.
